### PR TITLE
改名技能：MaxKB RAG-QA技能

### DIFF
--- a/tools/skill_maxkb_rag_qa/README.md
+++ b/tools/skill_maxkb_rag_qa/README.md
@@ -1,4 +1,4 @@
-# 智能MaxKB知识库检索
+# MaxKB RAG-QA技能
 
 面向 AI Agent 的通用 MaxKB RAG 检索技能。核心采用**统一、渐进式检索链路**，不人为区分简单问题和复杂问题：所有问题优先走 Vector/Blend，只有证据不足时才逐级升级到 Query Rewrite、Paragraph Fallback、Section/Context 和必要的多步检索。
 

--- a/tools/skill_maxkb_rag_qa/data.yaml
+++ b/tools/skill_maxkb_rag_qa/data.yaml
@@ -1,4 +1,4 @@
-name: 智能MaxKB知识库检索
+name: MaxKB RAG-QA技能
 tags:
   - Skills
 title: 基于 MaxKB 知识库的渐进式 RAG 检索与证据获取


### PR DESCRIPTION
将上一版已合并的「智能MaxKB知识库检索」技能名称修改为「MaxKB RAG-QA技能」。

- 更新 tools/skill_maxkb_rag_qa/data.yaml 的 name 字段
- 同步更新 README.md 标题

请审核。